### PR TITLE
fix generic encoders not accepting case classes with collection types other than Seq

### DIFF
--- a/src/test/scala/a14e/bson/decoder/DefaultBsonDecodersSpec.scala
+++ b/src/test/scala/a14e/bson/decoder/DefaultBsonDecodersSpec.scala
@@ -203,7 +203,7 @@ class DefaultBsonDecodersSpec extends FlatSpec with Matchers {
 
     val bson = new BsonArray(java.util.Arrays.asList(value1, value2))
 
-    BsonDecoder.seqDecoder[String].decode(bson) shouldBe Success(Seq("value1", "value2"))
+    BsonDecoder.seqDecoder[String, Seq].decode(bson) shouldBe Success(Seq("value1", "value2"))
 
   }
 
@@ -214,7 +214,7 @@ class DefaultBsonDecodersSpec extends FlatSpec with Matchers {
 
     val bson = new BsonArray(java.util.Arrays.asList(value1, value2, value3))
 
-    BsonDecoder.seqDecoder[String].decode(bson).isFailure shouldBe true
+    BsonDecoder.seqDecoder[String, Seq].decode(bson).isFailure shouldBe true
 
   }
 

--- a/src/test/scala/a14e/bson/decoder/GenericBsonDecodersSpec.scala
+++ b/src/test/scala/a14e/bson/decoder/GenericBsonDecodersSpec.scala
@@ -6,6 +6,7 @@ import a14e.bson.auto._
 import org.scalatest.{FlatSpec, Matchers}
 import BsonDecoder._
 import org.bson.BsonString
+
 import scala.util.Success
 
 case class SampleUser(id: ID[Int],
@@ -23,6 +24,9 @@ case class Level(levelNumber: Int,
 
 case class NamedNode(nodeName: String,
                      children: Map[String, NamedNode])
+
+case class ClassWithList(sequence: List[Int])
+case class ClassWithVector(sequence: Vector[Int])
 
 class GenericBsonDecodersSpec extends FlatSpec with Matchers {
 
@@ -143,5 +147,25 @@ class GenericBsonDecodersSpec extends FlatSpec with Matchers {
       )
     )
     bson.as[NamedNode] shouldBe node
+  }
+
+  it should "encode classes with different sequence types" in {
+
+    val nodeWithList =
+      ClassWithList(
+        sequence = List(1,2,3)
+      )
+
+    val nodeWithVector =
+      ClassWithVector(
+        sequence = Vector(1,2,3)
+      )
+
+    val bson = Bson.obj(
+      "sequence" -> Bson.arr(1, 2, 3)
+    )
+
+    bson.as[ClassWithList] shouldBe nodeWithList
+    bson.as[ClassWithVector] shouldBe nodeWithVector
   }
 }


### PR DESCRIPTION
```scala
import a14e.bson._
import a14e.bson.auto._

case class Fizz(x: List[Int] = List(1, 2))
case class FizzWithSeq(x: Seq[Int] = Seq(1, 2))

Fizz().asBson.as[Fizz] // would result in an "No bson implicit transformer found" error
Fizz().asBson.as[FizzWithSeq] // would work fine
```